### PR TITLE
Fix invalid UPC-A and EAN-13 barcodes

### DIFF
--- a/data/movie/Andrei Rublev (1966)/2018-criterion-blu-ray/release.json
+++ b/data/movie/Andrei Rublev (1966)/2018-criterion-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2018-criterion-blu-ray",
   "Asin": "B07DS1ZQBZ",
-  "Upc": "71551219310",
+  "Upc": "715515219310",
   "Year": 2018,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Billy Madison (1995)/2005-special-edition-dvd/release.json
+++ b/data/movie/Billy Madison (1995)/2005-special-edition-dvd/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2005-special-edition-dvd",
   "Asin": "B0009X761E",
-  "Upc": "02519254023",
+  "Upc": "025192545023",
   "Year": 1995,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Borat Cultural Learnings of America for Make Benefit Glorious Nation of Kazakhstan (2006)/2007-widescreen-dvd/release.json
+++ b/data/movie/Borat Cultural Learnings of America for Make Benefit Glorious Nation of Kazakhstan (2006)/2007-widescreen-dvd/release.json
@@ -1,7 +1,7 @@
 {
     "Slug": "2015-widescreen-dvd",
     "Asin": "B000MMMT9G",
-    "Upc": "02454343419693",
+    "Upc": "024543419693",
     "Year": 2015,
     "Locale": "en-us",
     "RegionCode": "1",

--- a/data/movie/District 9 (2009)/2020-4K/release.json
+++ b/data/movie/District 9 (2009)/2020-4K/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2020-4K",
   "Asin": "B08C4524YJ",
-  "Upc": "043396569326",
+  "Upc": "043396569324",
   "Year": 2020,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Eternal Sunshine of the Spotless Mind (2004)/2022-kino-lorber-4k/release.json
+++ b/data/movie/Eternal Sunshine of the Spotless Mind (2004)/2022-kino-lorber-4k/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2022-kino-lorber-4k",
   "Asin": "B09YS4QPYH",
-  "Upc": "73832925950",
+  "Upc": "738329259501",
   "Year": 2004,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Ghost (1990)/2017-blu-ray/release.json
+++ b/data/movie/Ghost (1990)/2017-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2017-blu-ray",
   "Asin": "B071G7GQ71",
-  "Upc": "03242925703",
+  "Upc": "032429257031",
   "Year": 2017,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/I Love You, Man (2009)/2017-blu-ray/release.json
+++ b/data/movie/I Love You, Man (2009)/2017-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2017-blu-ray",
   "Asin": "B01NCLDRW1",
-  "Upc": "09736071476",
+  "Upc": "097360714746",
   "Year": 2017,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/I, Robot (2004)/3d-2012/release.json
+++ b/data/movie/I, Robot (2004)/3d-2012/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "3d-2012",
   "Asin": "B00AZMFU62",
-  "Upc": "02454380753780",
+  "Upc": "024543807537",
   "Year": 2012,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Moana (2016)/3d-2017-uk/release.json
+++ b/data/movie/Moana (2016)/3d-2017-uk/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "3d-2017-uk",
   "Asin": "B01N6C541X",
-  "Upc": "8717418499462",
+  "Upc": "8717418499426",
   "Year": 2017,
   "Locale": "en-gb",
   "RegionCode": "2",

--- a/data/movie/Rain Man (1988)/2011-blu-ray/release.json
+++ b/data/movie/Rain Man (1988)/2011-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2011-blu-ray",
   "Asin": "B004H0ZH66",
-  "Upc": "88390430915480",
+  "Upc": "883904309154",
   "Year": 2011,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/The Campaign (2012)/2012-blu-ray/release.json
+++ b/data/movie/The Campaign (2012)/2012-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2012-blu-ray",
   "Asin": "B009CW55XY",
-  "Upc": "88392924073",
+  "Upc": "883929240739",
   "Year": 2012,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/The Incredible Hulk (2008)/2018-4k/release.json
+++ b/data/movie/The Incredible Hulk (2008)/2018-4k/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2018-4k",
   "Asin": "B079NBWT45",
-  "Upc": "91329053096",
+  "Upc": "191329053096",
   "Year": 2018,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/The Infiltrator (2016)/2016-blu-ray/release.json
+++ b/data/movie/The Infiltrator (2016)/2016-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2016-blu-ray",
   "Asin": "B01J1HPVBA",
-  "Upc": "825192366901",
+  "Upc": "025192366901",
   "Year": 2016,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/The King of Staten Island (2020)/2020-blu-ray/release.json
+++ b/data/movie/The King of Staten Island (2020)/2020-blu-ray/release.json
@@ -1,7 +1,7 @@
 {
   "Slug": "2020-blu-ray",
   "Asin": "B089TS14MZ",
-  "Upc": "191329137010",
+  "Upc": "191329137017",
   "Year": 2020,
   "Locale": "en-us",
   "RegionCode": "1",

--- a/data/movie/Toy Story 2 (1999)/2010-special-edition-blu-ray/release.json
+++ b/data/movie/Toy Story 2 (1999)/2010-special-edition-blu-ray/release.json
@@ -1,6 +1,6 @@
 {
     "Slug": "2010-special-edition-blu-ray",
-    "Upc": "86936798821",
+    "Upc": "786936798821",
     "Year": 2010,
     "Locale": "en-us",
     "RegionCode": "1",


### PR DESCRIPTION
These barcodes failed to pass validation as valid EAN-13 or UPC-A, and have been corrected. I verified each correction by either finding pictures of the release that show the barcode, or checking information available from online retailers.

Two releases contain questionable barcodes: "I, Robot (2004)" and "Rain Man (1988)". The barcodes on the packing of both releases have a suffix of "80" appended to the end of the UPC barcode. I cannot find a reason for this, as no relevant 14-digit barcode format exists and the original 12 digit UPC-A code identifies the releases correctly. Therefore I have simply removed the "80" suffix from each barcode.